### PR TITLE
updated app_dirs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ name = "concurr-jobsd"
 path = "src/server/main.rs"
 
 [dependencies]
-app_dirs = "1.1"
+app_dirs = "1.2.1"
 bytes = "0.4"
 chashmap = "2.2.0"
 coco = "0.3.0"


### PR DESCRIPTION
Don't know if this repo is dead or not, but I ran into an issue while building this that was easily fixed.

While building app_dirs = "1.1", specifically building rand v0.3.16, I get "cannot infer type for T
". This seems to be an issue with that specific version rand since when I updated app_dirs to 1.2.1, everything works. It was pretty simple to fix, so I'll just make a pull request which you can merge or reject at your leisure.